### PR TITLE
Added/changed autocomplete attr where necessary

### DIFF
--- a/src/views/home/confirmAccount.vue
+++ b/src/views/home/confirmAccount.vue
@@ -3,8 +3,8 @@
     <div class="confirm-account_center">
       <SaMuHeader>{{$t('confirm_account.title')}}</SaMuHeader>
       <form v-on:submit="handleSubmit">
-        <SaMuInput :placeholder="$t('confirm_account.password')" type="password" v-model="dto.password" id="confirm-account__password"/>
-        <SaMuInput :placeholder="$t('confirm_account.password_repeat')" type="password" v-model="repeatPassword" id="confirm-account__password-repeat"/>
+        <SaMuInput :placeholder="$t('confirm_account.password')" autocomplete="new-password" type="password" v-model="dto.password" id="confirm-account__password"/>
+        <SaMuInput :placeholder="$t('confirm_account.password_repeat')" autocomplete="new-password" type="password" v-model="repeatPassword" id="confirm-account__password-repeat"/>
         <b-button variant="samu" size="small" type="submit">{{$t('confirm_account.confirm')}}</b-button>
       </form>
     </div>

--- a/src/views/home/login.vue
+++ b/src/views/home/login.vue
@@ -9,7 +9,7 @@
               <SaMuInput
                 :placeholder="$t('form.email')"
                 type="text"
-                autocomplete="username"
+                autocomplete="email"
                 v-model="dto.email"
               />
               <SaMuInput

--- a/src/views/home/me.vue
+++ b/src/views/home/me.vue
@@ -14,8 +14,8 @@
                             <td><b>{{$t('general_information.last_name')}}</b></td>
                         </tr>
                         <tr>
-                            <td><SaMuInput type="text" v-model="user.firstName" :disabled="!editMode"/></td>
-                            <td><SaMuInput type="text" v-model="user.lastName" :disabled="!editMode"/></td>
+                            <td><SaMuInput type="text" autocomplete="given-name"  v-model="user.firstName" :disabled="!editMode"/></td>
+                            <td><SaMuInput type="text" autocomplete="family-name"  v-model="user.lastName" :disabled="!editMode"/></td>
                         </tr>
                         <tr>
                             <td><b>{{$t('general_information.birthday')}}</b></td>
@@ -23,7 +23,7 @@
                             
                         </tr>
                         <tr>
-                            <td><SaMuInput type="date" v-model="user.birthday" :disabled="!editMode"/></td>
+                            <td><SaMuInput type="date" autocomplete="bday" v-model="user.birthday" :disabled="!editMode"/></td>
                             <td><SaMuInput type="date" v-model="user.registeredSince" disabled/></td>
                         </tr>
                         <tr>
@@ -31,16 +31,16 @@
                             <td><b>{{$t('general_information.city')}}</b></td>
                         </tr>
                         <tr>
-                            <td><SaMuInput type="text" v-model="user.address" :disabled="!editMode"/></td>
-                            <td><SaMuInput type="text" v-model="user.city" :disabled="!editMode"/></td>
+                            <td><SaMuInput type="text" autocomplete="street-address" v-model="user.address" :disabled="!editMode"/></td>
+                            <td><SaMuInput type="text" autocomplete="address-level2" v-model="user.city" :disabled="!editMode"/></td>
                         </tr>
                         <tr>
                             <td><b>{{$t('general_information.postalcode')}}</b></td>
                             <td><b>{{$t('general_information.country')}}</b></td>
                         </tr>
                         <tr>
-                            <td><SaMuInput type="text" v-model="user.postalcode" :disabled="!editMode"/></td>
-                            <td><SaMuInput type="text" v-model="user.country" :disabled="!editMode"/></td>
+                            <td><SaMuInput type="text" autocomplete="postal-code" v-model="user.postalcode" :disabled="!editMode"/></td>
+                            <td><SaMuInput type="text" autocomplete="country-name" v-model="user.country" :disabled="!editMode"/></td>
                         </tr>
                     </table>
                 </b-col>
@@ -53,13 +53,13 @@
                         </tr>
                         <tr>
                             <td><SaMuInput type="text" v-model="user.pcn" :disabled="!editMode"/></td>
-                            <td><SaMuInput type="email" v-model="user.email" :disabled="!editMode"/></td>
+                            <td><SaMuInput type="email" autocomplete="email" v-model="user.email" :disabled="!editMode"/></td>
                         </tr>
                         <tr>
                             <td><b>{{$t('digital_information.phonenumber')}}</b></td>
                         </tr>
                         <tr>
-                            <td><SaMuInput type="tel" v-model="user.phoneNumber" :disabled="!editMode"/></td>
+                            <td><SaMuInput type="tel" autocomplete="tel" v-model="user.phoneNumber" :disabled="!editMode"/></td>
                         </tr>
                     </table>
                 </b-col>

--- a/src/views/home/register.vue
+++ b/src/views/home/register.vue
@@ -7,13 +7,13 @@
                     <div class="register-form general-information">
                         <SaMuBadge text="1">{{$t('form.general_info')}}</SaMuBadge>
                         <div class="register-form__body">
-                            <SaMuInput :placeholder="$t('form.first_name')" type="text" v-model="dto.firstName" id="register-form__first_name"/>
-                            <SaMuInput :placeholder="$t('form.last_name')" type="text" v-model="dto.lastName" id="register-form__last_name"/>
-                            <SaMuInput :placeholder="$t('form.birthday')" type="date" v-model="dto.birthday" id="register-form__birthday"/>
-                            <SaMuInput :placeholder="$t('form.address')" type="text" v-model="dto.address" id="register-form__address"/>
-                            <SaMuInput :placeholder="$t('form.city')" type="text" v-model="dto.city" id="register-form__city"/>
-                            <SaMuInput :placeholder="$t('form.postalcode')" type="text" v-model="dto.postalcode" id="register-form__postalcode"/>
-                            <SaMuInput :placeholder="$t('form.country')" type="text" v-model="dto.country" id="register-form__country"/>
+                            <SaMuInput :placeholder="$t('form.first_name')" autocomplete="given-name" type="text" v-model="dto.firstName" id="register-form__first_name"/>
+                            <SaMuInput :placeholder="$t('form.last_name')" autocomplete="family-name" type="text" v-model="dto.lastName" id="register-form__last_name"/>
+                            <SaMuInput :placeholder="$t('form.birthday')" autocomplete="bday" type="date" v-model="dto.birthday" id="register-form__birthday"/>
+                            <SaMuInput :placeholder="$t('form.address')" autocomplete="street-address" type="text" v-model="dto.address" id="register-form__address"/>
+                            <SaMuInput :placeholder="$t('form.city')" autocomplete="address-level2" type="text" v-model="dto.city" id="register-form__city"/>
+                            <SaMuInput :placeholder="$t('form.postalcode')" autocomplete="postal-code" type="text" v-model="dto.postalcode" id="register-form__postalcode"/>
+                            <SaMuInput :placeholder="$t('form.country')" autocomplete="country-name" type="text" v-model="dto.country" id="register-form__country"/>
                         </div>
                     </div>
                 </b-col>
@@ -22,8 +22,8 @@
                         <SaMuBadge text="2">{{$t('form.digital_data')}}</SaMuBadge>
                         <div class="register-form__body">
                             <SaMuInput :placeholder="$t('form.ipcn')" type="text" v-model="dto.pcn" id="register-form__pcn"/>
-                            <SaMuInput :placeholder="$t('form.phonenumber')" type="text" v-model="dto.phoneNumber" id="register-form__phonenumber"/>
-                            <SaMuInput :placeholder="$t('form.email')" type="email" v-model="dto.email" id="register-form__email"/>
+                            <SaMuInput :placeholder="$t('form.phonenumber')" autocomplete="tel" type="text" v-model="dto.phoneNumber" id="register-form__phonenumber"/>
+                            <SaMuInput :placeholder="$t('form.email')" autocomplete="email" type="email" v-model="dto.email" id="register-form__email"/>
                             <b-button variant="samu" size="small" type="submit">{{$t('form.send')}}</b-button>
                         </div>
                     </div>


### PR DESCRIPTION
<!--
Do not change this template, because of the SaMuBot
-->

**Type update**
- [ ] Major (v1.0.0 -> v2.0.0)
- [ ] Minor (v1.0.0 -> v1.1.0)
- [x] Patch (v1.0.0 -> v1.0.1)

**Omschrijving update**

I noticed the site not having proper autocomplete values when I updated my account details. Because of this, I added them where I seemed fit. I excluded it from the `dashboard/member/details` view because I don't think autocompleting would be smart for that.

Now when a user has added their prefered form field values in their browser the proper values will be filled in.

**Collaborators**
None